### PR TITLE
Call account API endpoint for get_account_details tool

### DIFF
--- a/tool/entity_tools.py
+++ b/tool/entity_tools.py
@@ -110,27 +110,27 @@ class EntityMCPTools:
             Field(description="Fields to exclude in the response object. Accepts comma-separated list.")
         ] = None,
         include_access_history: Annotated[
-            bool | None, 
+            bool, 
             Field(description="Include account access history in the response")
-        ] = None,
+        ] = False,
         include_detection_summaries: Annotated[
-            bool | None, 
-            Field(description="Include detection summaries in the response")
-        ] = None,
+            bool, 
+            Field(description="Include detection summaries for the detections on the account in the response object.")
+        ] = True,
         include_external: Annotated[
-            bool | None, 
-            Field(description="Include external data in the response")
-        ] = None,
+            bool, 
+            Field(description="Include external data in the response object.")
+        ] = False,
         src_linked_account: Annotated[
             str | None, 
             Field(description="Source linked account filter")
-        ] = None
+        ] = False
     ) -> str:
         """
-        Get complete detailed information about a specific account entity using the v3.4 accounts API endpoint.
+        Get complete detailed information about a specific account entity. This tool returns account details including detections, scoring information, associated accounts, access history, detection summaries, external data, and more. Response can be customized using various parameters to include or exclude specific fields and related data.
         
         Returns:
-            str: Formatted string with detailed information about the account. It includes detections, scoring information, associated accounts, access history, detection summaries, external data, and more.
+            str: JSON string with detailed information about the account. It includes detections, scoring information, associated accounts, access history, detection summaries, external data, and more.
             If the account is not found, returns a message indicating that no account was found with the specified ID.
             If an error occurs during the request, raises an exception with the error message.
         """

--- a/tool/entity_tools.py
+++ b/tool/entity_tools.py
@@ -100,23 +100,53 @@ class EntityMCPTools:
      
     async def get_account_details(
         self,
-        account_id: Annotated[int, Field(description="ID of the account in Vectra platform to retrieve details for", ge=1)]
+        account_id: Annotated[int, Field(description="ID of the account in Vectra platform to retrieve details for", ge=1)],
+        fields: Annotated[
+            list[str] | None, 
+            Field(description="Fields to return in the results. Available fields: id, url, account_type, assignment, associated_accounts, certainty, data_source, detection_set, detection_summaries, last_detection_timestamp, name, note, note_modified_by, note_modified_timestamp, notes, past_assignments, privilege_category, privilege_level, probable_home, sensors, severity, state, tags, threat")
+        ] = None,
+        exclude_fields: Annotated[
+            list[str] | None, 
+            Field(description="Fields to exclude in the response object. Accepts comma-separated list.")
+        ] = None,
+        include_access_history: Annotated[
+            bool | None, 
+            Field(description="Include account access history in the response")
+        ] = None,
+        include_detection_summaries: Annotated[
+            bool | None, 
+            Field(description="Include detection summaries in the response")
+        ] = None,
+        include_external: Annotated[
+            bool | None, 
+            Field(description="Include external data in the response")
+        ] = None,
+        src_linked_account: Annotated[
+            str | None, 
+            Field(description="Source linked account filter")
+        ] = None
     ) -> str:
         """
-        Get complete detailed information about a specific account entity.
+        Get complete detailed information about a specific account entity using the v3.4 accounts API endpoint.
         
         Returns:
-            str: Formatted string with detailed information about the account entity. 
+            str: Formatted string with detailed information about the account. It includes detections, scoring information, associated accounts, access history, detection summaries, external data, and more.
             If the account is not found, returns a message indicating that no account was found with the specified ID.
             If an error occurs during the request, raises an exception with the error message.
         """
         try:
-            # Fetch account details using the client
-            account_details = await self.client.get_entity(
-                entity_id = account_id, 
-                entity_type = "account"  # Specify the type as account
+            # Fetch account details using the v3.4 accounts API endpoint
+            account_details = await self.client.get_account(
+                account_id=account_id,
+                fields=fields,
+                exclude_fields=exclude_fields,
+                include_access_history=include_access_history,
+                include_detection_summaries=include_detection_summaries,
+                include_external=include_external,
+                src_linked_account=src_linked_account
             )
-            # Check if the host was found
+            
+            # Check if the account was found
             if 'detail' in account_details and account_details['detail'] == 'Not found.':
                 return f"No account found with ID: {account_id}."
             

--- a/vectra_client.py
+++ b/vectra_client.py
@@ -406,9 +406,31 @@ class VectraClient:
         else:
             return await self._make_request("GET", "accounts", params=params)
     
-    async def get_account(self, account_id: int) -> Dict[str, Any]:
-        """Get specific account by ID."""
-        return await self._make_request("GET", f"accounts/{account_id}")
+    async def get_account(
+        self, 
+        account_id: int,
+        fields: Optional[List[str]] = None,
+        exclude_fields: Optional[List[str]] = None,
+        include_access_history: Optional[bool] = None,
+        include_detection_summaries: Optional[bool] = None,
+        include_external: Optional[bool] = None,
+        src_linked_account: Optional[str] = None
+    ) -> Dict[str, Any]:
+        """Get specific account by ID with optional field filtering and additional parameters."""
+        params = {}
+        if fields:
+            params["fields"] = ",".join(fields)
+        if exclude_fields:
+            params["exclude_fields"] = ",".join(exclude_fields)
+        if include_access_history is not None:
+            params["include_access_history"] = include_access_history
+        if include_detection_summaries is not None:
+            params["include_detection_summaries"] = include_detection_summaries
+        if include_external is not None:
+            params["include_external"] = include_external
+        if src_linked_account:
+            params["src_linked_account"] = src_linked_account
+        return await self._make_request("GET", f"accounts/{account_id}", params=params)
     
     # Host endpoints
     async def get_hosts(


### PR DESCRIPTION
The MCP server is using the entities API endpoint instead of the account API endpoint for the tool get_account_details. This PR is changing this behavior.

- Update get_account_details to use the account endpoint.
- Add new parameters for get_account_details tool.
- Update get_account function

The account API endpoint returns important information such as associated accounts which are not available in the entities endpoint.