### PR TITLE
Add multi-tenant support and fix E2E bugs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,8 @@
-# Vectra AI Platform Configuration
+# Vectra AI Platform Configuration (Single-Tenant Mode)
+#
+# For multi-tenant setup, use a YAML config file instead:
+#   VECTRA_CONFIG_FILE=tenants.yaml
+# See tenants.yaml.example for details.
 VECTRA_BASE_URL=https://123456789.ab1.portal.vectra.ai
 VECTRA_CLIENT_ID=<your-client-id>
 VECTRA_CLIENT_SECRET=<your-client-secret>

--- a/.gitignore
+++ b/.gitignore
@@ -158,6 +158,7 @@ celerybeat.pid
 
 # Environments
 .env
+tenants.yaml
 .venv
 env/
 venv/

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,9 @@ COPY tool/ ./tool/
 COPY utils/ ./utils/
 COPY prompt/ ./prompt/
 
+# Copy tenants YAML config if present (optional for multi-tenant mode)
+COPY tenants.yaml* ./
+
 # Install uv via pip and sync dependencies
 RUN pip install --no-cache-dir uv && \
     uv sync --frozen

--- a/README.md
+++ b/README.md
@@ -43,17 +43,41 @@ pip install uv
 cd your-project-directory
 ```
 
-3. **Configure environment variables:**
-```
+3. **Configure credentials:**
+
+#### Option A: Single Tenant (`.env` file)
+```bash
 # Copy the example environment file
 cp .env.example .env
 ```
-Then edit the .env file with your actual Vectra AI Platform credentials. 
+Then edit the `.env` file with your actual Vectra AI Platform credentials.
 Required variables to update:
 
 * `VECTRA_BASE_URL`: Your Vectra portal URL
 * `VECTRA_CLIENT_ID`: Your client ID from Vectra
 * `VECTRA_CLIENT_SECRET`: Your client secret from Vectra
+
+#### Option B: Multiple Tenants (YAML config)
+If you have multiple Vectra tenants, use a YAML configuration file instead:
+```bash
+cp tenants.yaml.example tenants.yaml
+```
+Then edit `tenants.yaml` with your tenant details:
+```yaml
+tenants:
+  - name: prod
+    base_url: https://prod-tenant.uw2.portal.vectra.ai
+    client_id: "<prod-client-id>"
+    client_secret: "<prod-client-secret>"
+
+  - name: staging
+    base_url: https://staging-tenant.uw2.portal.vectra.ai
+    client_id: "<staging-client-id>"
+    client_secret: "<staging-client-secret>"
+```
+Each tenant gets its own set of tools prefixed with the tenant name (e.g., `prod_list_detections`, `staging_list_detections`). A `list_tenants` meta-tool is also added to discover available tenants.
+
+Per-tenant values can be overridden via environment variables using the pattern `VECTRA_TENANT_<NAME>_<FIELD>` (e.g., `VECTRA_TENANT_PROD_CLIENT_SECRET`). This is useful for Docker/Kubernetes where secrets should not be stored in files.
 
 4. **Create and activate a virtual environment:**
 ```
@@ -88,6 +112,10 @@ python server.py --transport sse --host 0.0.0.0 --port 8000
 # Run with streamable-http transport (for production HTTP deployments)
 python server.py --transport streamable-http --host 0.0.0.0 --port 8000
 
+# Run with multi-tenant YAML config
+python server.py --config tenants.yaml
+python server.py -c tenants.yaml --transport sse
+
 # Enable debug logging
 python server.py --debug
 ```
@@ -120,7 +148,9 @@ notepad %APPDATA%/Claude/claude_desktop_config.json
 ```
 
 Add the following configuration to the `mcpServers` section (update the paths to match your setup):
-```
+
+**Single Tenant:**
+```json
 {
   "mcpServers": {
     "vectra-ai-mcp": {
@@ -136,17 +166,19 @@ Add the following configuration to the `mcpServers` section (update the paths to
 }
 ```
 
-Example with actual paths:
-```
+**Multi-Tenant:**
+```json
 {
   "mcpServers": {
     "vectra-ai-mcp": {
-      "command": "/Users/yourusername/.local/bin/uv",
+      "command": "/path/to/your/uv/binary",
       "args": [
         "--directory",
-        "/Users/yourusername/path/to/vectra-mcp-project",
+        "/path/to/your/project/directory",
         "run",
-        "server.py"
+        "server.py",
+        "--config",
+        "tenants.yaml"
       ]
     }
   }
@@ -343,6 +375,38 @@ docker run -d \
   vectra-mcp-server
 ```
 
+## Docker Multi-Tenant Setup
+
+To run the server in multi-tenant mode with Docker:
+
+1. Create a `tenants.yaml` file (see `tenants.yaml.example`).
+2. Mount it into the container and set `VECTRA_CONFIG_FILE`:
+
+```bash
+docker run -d \
+  --name vectra-mcp-server \
+  -e VECTRA_CONFIG_FILE=/app/tenants.yaml \
+  -e VECTRA_MCP_TRANSPORT=streamable-http \
+  -e VECTRA_MCP_HOST=0.0.0.0 \
+  -e VECTRA_MCP_PORT=8000 \
+  -v ./tenants.yaml:/app/tenants.yaml:ro \
+  -p 8000:8000 \
+  --restart unless-stopped \
+  ghcr.io/vectra-ai-research/vectra-ai-mcp-server:latest
+```
+
+You can inject secrets per-tenant via environment variables instead of storing them in the YAML file:
+```bash
+docker run -d \
+  --name vectra-mcp-server \
+  -e VECTRA_CONFIG_FILE=/app/tenants.yaml \
+  -e VECTRA_TENANT_PROD_CLIENT_SECRET=<secret> \
+  -e VECTRA_TENANT_STAGING_CLIENT_SECRET=<secret> \
+  -v ./tenants.yaml:/app/tenants.yaml:ro \
+  -p 8000:8000 \
+  ghcr.io/vectra-ai-research/vectra-ai-mcp-server:latest
+```
+
 ## Docker Environment Variables
 
 The Docker container supports all the same environment variables as the local setup, plus additional MCP server configuration:
@@ -352,6 +416,17 @@ The Docker container supports all the same environment variables as the local se
 - `VECTRA_MCP_HOST`: Host to bind to for HTTP transports - default: `0.0.0.0`
 - `VECTRA_MCP_PORT`: Port for HTTP transports - default: `8000`
 - `VECTRA_MCP_DEBUG`: Enable debug logging - default: `false`
+- `VECTRA_CONFIG_FILE`: Path to YAML config file for multi-tenant mode (optional)
+
+### Multi-Tenant Override Variables
+When using a YAML config file, per-tenant settings can be overridden via environment variables:
+- `VECTRA_TENANT_<NAME>_BASE_URL`
+- `VECTRA_TENANT_<NAME>_CLIENT_ID`
+- `VECTRA_TENANT_<NAME>_CLIENT_SECRET`
+- `VECTRA_TENANT_<NAME>_API_VERSION`
+- `VECTRA_TENANT_<NAME>_REQUEST_TIMEOUT`
+
+Where `<NAME>` is the tenant name in uppercase (e.g., `VECTRA_TENANT_PROD_CLIENT_SECRET`).
 
 ### Accessing the HTTP Server
 

--- a/config.py
+++ b/config.py
@@ -1,99 +1,117 @@
-"""Configuration management for Vectra MCP Server."""
+"""Configuration management for Vectra MCP Server.
+
+Supports two modes:
+  1. Legacy single-tenant: reads from environment variables / .env file (backward compatible).
+  2. Multi-tenant YAML: reads tenants from a YAML config file, with per-tenant env var overrides.
+"""
 
 import os
-from typing import Optional
-from pydantic import Field, field_validator
+import re
+import logging
+from typing import Optional, List
+
+import yaml
+from pydantic import BaseModel, Field, field_validator
 from pydantic_settings import BaseSettings
 from dotenv import load_dotenv
 
 # Load environment variables from .env file
 load_dotenv()
 
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Shared validators
+# ---------------------------------------------------------------------------
+
+_SUPPORTED_API_VERSIONS = ["v3", "v3.1", "v3.2", "v3.3", "v3.4"]
+_VALID_LOG_LEVELS = ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
+_VALID_LOG_FORMATS = ["json", "text"]
+# Tenant names must be safe for MCP tool name prefixes (alphanumeric + underscore, 1-20 chars)
+_TENANT_NAME_RE = re.compile(r"^[a-zA-Z][a-zA-Z0-9_]{0,19}$")
+
+
+def _validate_base_url(v: str) -> str:
+    """Validate and normalize a base URL."""
+    if not v:
+        raise ValueError("base_url is required")
+    v = v.rstrip("/")
+    if not v.startswith(("http://", "https://")):
+        v = f"https://{v}"
+    return v
+
+
+def _validate_api_version(v: str) -> str:
+    if v not in _SUPPORTED_API_VERSIONS:
+        raise ValueError(f"Unsupported API version: {v}. Supported versions: {_SUPPORTED_API_VERSIONS}")
+    return v
+
+
+# ---------------------------------------------------------------------------
+# Legacy single-tenant config (backward compatible)
+# ---------------------------------------------------------------------------
 
 class VectraConfig(BaseSettings):
-    """Configuration settings for Vectra MCP Server."""
-    
+    """Configuration settings for Vectra MCP Server (single-tenant / legacy)."""
+
     # Vectra API Configuration
     base_url: str = Field(alias="VECTRA_BASE_URL")
     client_id: str = Field(alias="VECTRA_CLIENT_ID")
     client_secret: str = Field(alias="VECTRA_CLIENT_SECRET")
     api_version: str = Field(default="v3.4", alias="VECTRA_API_VERSION")
     oauth_token_url_override: Optional[str] = Field(default=None, alias="VECTRA_OAUTH_TOKEN_URL")
-    
+
     # Request Configuration
     request_timeout: int = Field(default=30, alias="VECTRA_REQUEST_TIMEOUT")
     rate_limit_requests: int = Field(default=100, alias="VECTRA_RATE_LIMIT_REQUESTS")
     rate_limit_period: int = Field(default=60, alias="VECTRA_RATE_LIMIT_PERIOD")
-    
+
     # Cache Configuration
     cache_ttl: int = Field(default=300, alias="VECTRA_CACHE_TTL")
-    
+
     # Logging Configuration
     log_level: str = Field(default="INFO", alias="LOG_LEVEL")
     log_format: str = Field(default="json", alias="LOG_FORMAT")
-    
+
     # Development Configuration
     dev_mode: bool = Field(default=False, alias="DEV_MODE")
-    
+
     @field_validator("base_url")
     @classmethod
     def validate_base_url(cls, v: str) -> str:
-        """Validate and normalize the base URL."""
-        if not v:
-            raise ValueError("VECTRA_BASE_URL is required")
-        
-        # Remove trailing slash
-        v = v.rstrip("/")
-        
-        # Ensure HTTPS
-        if not v.startswith(("http://", "https://")):
-            v = f"https://{v}"
-        
-        return v
-    
+        return _validate_base_url(v)
+
     @field_validator("api_version")
     @classmethod
     def validate_api_version(cls, v: str) -> str:
-        """Validate the API version."""
-        supported_versions = ["v3", "v3.1", "v3.2", "v3.3", "v3.4"]
-        if v not in supported_versions:
-            raise ValueError(f"Unsupported API version: {v}. Supported versions: {supported_versions}")
-        return v
-    
+        return _validate_api_version(v)
+
     @field_validator("log_level")
     @classmethod
     def validate_log_level(cls, v: str) -> str:
-        """Validate the log level."""
-        valid_levels = ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
         v = v.upper()
-        if v not in valid_levels:
-            raise ValueError(f"Invalid log level: {v}. Valid levels: {valid_levels}")
+        if v not in _VALID_LOG_LEVELS:
+            raise ValueError(f"Invalid log level: {v}. Valid levels: {_VALID_LOG_LEVELS}")
         return v
-    
+
     @field_validator("log_format")
     @classmethod
     def validate_log_format(cls, v: str) -> str:
-        """Validate the log format."""
-        valid_formats = ["json", "text"]
         v = v.lower()
-        if v not in valid_formats:
-            raise ValueError(f"Invalid log format: {v}. Valid formats: {valid_formats}")
+        if v not in _VALID_LOG_FORMATS:
+            raise ValueError(f"Invalid log format: {v}. Valid formats: {_VALID_LOG_FORMATS}")
         return v
-    
+
     @property
     def api_base_url(self) -> str:
-        """Get the full API base URL."""
         return f"{self.base_url}/api/{self.api_version}"
-    
+
     @property
     def oauth_token_url(self) -> str:
-        """Get the OAuth token URL."""
         if self.oauth_token_url_override:
             return self.oauth_token_url_override
-        
-        # Try common OAuth endpoints for Vectra tenants
         return f"{self.base_url}/oauth2/token"
-    
+
     model_config = {
         "env_file": ".env",
         "env_file_encoding": "utf-8",
@@ -101,6 +119,276 @@ class VectraConfig(BaseSettings):
         "extra": "ignore",
         "populate_by_name": True
     }
+
+
+# ---------------------------------------------------------------------------
+# Multi-tenant tenant descriptor
+# ---------------------------------------------------------------------------
+
+class TenantConfig(BaseModel):
+    """Configuration for a single Vectra tenant."""
+
+    name: str = Field(description="Short identifier used as tool name prefix (e.g. 'prod')")
+    base_url: str
+    client_id: str
+    client_secret: str
+    api_version: str = "v3.4"
+    oauth_token_url_override: Optional[str] = None
+    request_timeout: int = 30
+    rate_limit_requests: int = 100
+    rate_limit_period: int = 60
+    cache_ttl: int = 300
+
+    @field_validator("name")
+    @classmethod
+    def validate_name(cls, v: str) -> str:
+        if not _TENANT_NAME_RE.match(v):
+            raise ValueError(
+                f"Invalid tenant name '{v}'. Must start with a letter, contain only "
+                f"alphanumerics/underscores, and be 1-20 characters."
+            )
+        return v
+
+    @field_validator("base_url")
+    @classmethod
+    def validate_base_url(cls, v: str) -> str:
+        return _validate_base_url(v)
+
+    @field_validator("api_version")
+    @classmethod
+    def validate_api_version(cls, v: str) -> str:
+        return _validate_api_version(v)
+
+    @property
+    def api_base_url(self) -> str:
+        return f"{self.base_url}/api/{self.api_version}"
+
+    @property
+    def oauth_token_url(self) -> str:
+        if self.oauth_token_url_override:
+            return self.oauth_token_url_override
+        return f"{self.base_url}/oauth2/token"
+
+
+def _tenant_config_from_vectra_config(cfg: VectraConfig) -> TenantConfig:
+    """Convert a legacy VectraConfig into a TenantConfig (single-tenant, no prefix)."""
+    return TenantConfig(
+        name="default",
+        base_url=cfg.base_url,
+        client_id=cfg.client_id,
+        client_secret=cfg.client_secret,
+        api_version=cfg.api_version,
+        oauth_token_url_override=cfg.oauth_token_url_override,
+        request_timeout=cfg.request_timeout,
+        rate_limit_requests=cfg.rate_limit_requests,
+        rate_limit_period=cfg.rate_limit_period,
+        cache_ttl=cfg.cache_ttl,
+    )
+
+
+def _vectra_config_from_tenant(tenant: TenantConfig, legacy_cfg: Optional[VectraConfig] = None) -> VectraConfig:
+    """Create a VectraConfig from a TenantConfig so VectraClient works unchanged.
+
+    If *legacy_cfg* is provided, global settings (log_level, log_format, dev_mode)
+    are inherited from it; otherwise defaults are used.
+    """
+    return VectraConfig(
+        VECTRA_BASE_URL=tenant.base_url,
+        VECTRA_CLIENT_ID=tenant.client_id,
+        VECTRA_CLIENT_SECRET=tenant.client_secret,
+        VECTRA_API_VERSION=tenant.api_version,
+        VECTRA_OAUTH_TOKEN_URL=tenant.oauth_token_url_override,
+        VECTRA_REQUEST_TIMEOUT=tenant.request_timeout,
+        VECTRA_RATE_LIMIT_REQUESTS=tenant.rate_limit_requests,
+        VECTRA_RATE_LIMIT_PERIOD=tenant.rate_limit_period,
+        VECTRA_CACHE_TTL=tenant.cache_ttl,
+        LOG_LEVEL=legacy_cfg.log_level if legacy_cfg else os.environ.get("LOG_LEVEL", "INFO"),
+        LOG_FORMAT=legacy_cfg.log_format if legacy_cfg else os.environ.get("LOG_FORMAT", "json"),
+        DEV_MODE=legacy_cfg.dev_mode if legacy_cfg else (os.environ.get("DEV_MODE", "false").lower() == "true"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# YAML loader with per-tenant env var overrides
+# ---------------------------------------------------------------------------
+
+# Fields that can be overridden per tenant via VECTRA_TENANT_<NAME>_<FIELD> env vars
+_TENANT_ENV_FIELDS = {
+    "BASE_URL": "base_url",
+    "CLIENT_ID": "client_id",
+    "CLIENT_SECRET": "client_secret",
+    "API_VERSION": "api_version",
+    "OAUTH_TOKEN_URL": "oauth_token_url_override",
+    "REQUEST_TIMEOUT": "request_timeout",
+    "RATE_LIMIT_REQUESTS": "rate_limit_requests",
+    "RATE_LIMIT_PERIOD": "rate_limit_period",
+    "CACHE_TTL": "cache_ttl",
+}
+
+
+def _apply_env_overrides(tenant_dict: dict) -> dict:
+    """Apply environment variable overrides for a tenant.
+
+    Pattern: ``VECTRA_TENANT_<NAME_UPPER>_<FIELD>``
+    Example: ``VECTRA_TENANT_PROD_BASE_URL`` overrides ``base_url`` for tenant "prod".
+    """
+    name = tenant_dict.get("name", "")
+    prefix = f"VECTRA_TENANT_{name.upper()}_"
+
+    for env_suffix, field_name in _TENANT_ENV_FIELDS.items():
+        env_var = f"{prefix}{env_suffix}"
+        value = os.environ.get(env_var)
+        if value is not None:
+            # Convert integer fields
+            if field_name in ("request_timeout", "rate_limit_requests", "rate_limit_period", "cache_ttl"):
+                value = int(value)
+            tenant_dict[field_name] = value
+            logger.debug("Env override %s applied for tenant '%s'", env_var, name)
+
+    return tenant_dict
+
+
+def load_tenants_from_yaml(config_path: str) -> List[TenantConfig]:
+    """Load tenant configurations from a YAML file, applying env var overrides.
+
+    Args:
+        config_path: Path to the YAML config file.
+
+    Returns:
+        List of validated TenantConfig objects.
+
+    Raises:
+        FileNotFoundError: If the config file does not exist.
+        ValueError: If the YAML structure is invalid or a tenant config fails validation.
+    """
+    if not os.path.isfile(config_path):
+        raise FileNotFoundError(f"Configuration file not found: {config_path}")
+
+    with open(config_path, "r") as f:
+        data = yaml.safe_load(f)
+
+    if not isinstance(data, dict) or "tenants" not in data:
+        raise ValueError(f"YAML config must contain a top-level 'tenants' key: {config_path}")
+
+    raw_tenants = data["tenants"]
+    if not isinstance(raw_tenants, list) or len(raw_tenants) == 0:
+        raise ValueError(f"'tenants' must be a non-empty list in: {config_path}")
+
+    tenants: List[TenantConfig] = []
+    seen_names: set = set()
+
+    for idx, raw in enumerate(raw_tenants):
+        if not isinstance(raw, dict):
+            raise ValueError(f"Tenant entry {idx} must be a mapping in: {config_path}")
+
+        # Apply env var overrides
+        raw = _apply_env_overrides(raw)
+
+        tenant = TenantConfig(**raw)
+
+        if tenant.name in seen_names:
+            raise ValueError(f"Duplicate tenant name '{tenant.name}' in: {config_path}")
+        seen_names.add(tenant.name)
+
+        tenants.append(tenant)
+
+    return tenants
+
+
+# ---------------------------------------------------------------------------
+# Unified loader
+# ---------------------------------------------------------------------------
+
+class ServerConfiguration:
+    """Holds the resolved server configuration (single or multi-tenant).
+
+    Attributes:
+        tenants: List of tenant configs. In single-tenant mode this has exactly one entry.
+        is_multi_tenant: True when multiple tenants are configured.
+        log_level: Global log level.
+        log_format: Global log format.
+        dev_mode: Global dev mode flag.
+    """
+
+    def __init__(
+        self,
+        tenants: List[TenantConfig],
+        is_multi_tenant: bool,
+        log_level: str = "INFO",
+        log_format: str = "json",
+        dev_mode: bool = False,
+    ):
+        self.tenants = tenants
+        self.is_multi_tenant = is_multi_tenant
+        self.log_level = log_level
+        self.log_format = log_format
+        self.dev_mode = dev_mode
+
+    def vectra_config_for_tenant(self, tenant: TenantConfig) -> VectraConfig:
+        """Build a VectraConfig for a given tenant (so VectraClient works unchanged)."""
+        return VectraConfig(
+            VECTRA_BASE_URL=tenant.base_url,
+            VECTRA_CLIENT_ID=tenant.client_id,
+            VECTRA_CLIENT_SECRET=tenant.client_secret,
+            VECTRA_API_VERSION=tenant.api_version,
+            VECTRA_OAUTH_TOKEN_URL=tenant.oauth_token_url_override,
+            VECTRA_REQUEST_TIMEOUT=tenant.request_timeout,
+            VECTRA_RATE_LIMIT_REQUESTS=tenant.rate_limit_requests,
+            VECTRA_RATE_LIMIT_PERIOD=tenant.rate_limit_period,
+            VECTRA_CACHE_TTL=tenant.cache_ttl,
+            LOG_LEVEL=self.log_level,
+            LOG_FORMAT=self.log_format,
+            DEV_MODE=self.dev_mode,
+        )
+
+
+def load_configuration(config_file: Optional[str] = None) -> ServerConfiguration:
+    """Load the server configuration.
+
+    Resolution order:
+      1. If *config_file* is provided (or ``VECTRA_CONFIG_FILE`` env var is set)
+         and the file exists, load multi-tenant config from YAML.
+      2. Otherwise, fall back to legacy single-tenant config from environment/.env.
+
+    Returns:
+        A ``ServerConfiguration`` instance.
+    """
+    config_path = config_file or os.environ.get("VECTRA_CONFIG_FILE")
+
+    # Global settings from env (used regardless of mode)
+    log_level = os.environ.get("LOG_LEVEL", "INFO").upper()
+    log_format = os.environ.get("LOG_FORMAT", "json").lower()
+    dev_mode = os.environ.get("DEV_MODE", "false").lower() == "true"
+
+    if config_path and os.path.isfile(config_path):
+        logger.info("Loading multi-tenant configuration from %s", config_path)
+        tenants = load_tenants_from_yaml(config_path)
+        return ServerConfiguration(
+            tenants=tenants,
+            is_multi_tenant=True,
+            log_level=log_level,
+            log_format=log_format,
+            dev_mode=dev_mode,
+        )
+
+    # Legacy single-tenant mode
+    logger.info("Loading single-tenant configuration from environment")
+    legacy_cfg = VectraConfig()
+    tenant = _tenant_config_from_vectra_config(legacy_cfg)
+    return ServerConfiguration(
+        tenants=[tenant],
+        is_multi_tenant=False,
+        log_level=legacy_cfg.log_level,
+        log_format=legacy_cfg.log_format,
+        dev_mode=legacy_cfg.dev_mode,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Backward-compatible globals (for code that still calls init_config / get_global_config)
+# ---------------------------------------------------------------------------
+
+config: Optional[VectraConfig] = None
 
 
 def get_config() -> VectraConfig:
@@ -114,10 +402,6 @@ def load_config_from_env() -> VectraConfig:
         return VectraConfig()
     except Exception as e:
         raise RuntimeError(f"Failed to load configuration: {e}")
-
-
-# Global configuration instance
-config: Optional[VectraConfig] = None
 
 
 def init_config() -> VectraConfig:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,31 +10,44 @@ services:
       - "8000:8000"
     environment:
       # Vectra API Configuration - Set these values
+      # For single-tenant mode (backward compatible):
       - VECTRA_BASE_URL=${VECTRA_BASE_URL}
       - VECTRA_CLIENT_ID=${VECTRA_CLIENT_ID}
       - VECTRA_CLIENT_SECRET=${VECTRA_CLIENT_SECRET}
       - VECTRA_API_VERSION=${VECTRA_API_VERSION:-v3.4}
       - VECTRA_OAUTH_TOKEN_URL=${VECTRA_OAUTH_TOKEN_URL}
-      
+
+      # For multi-tenant mode, set VECTRA_CONFIG_FILE to point to a YAML config:
+      - VECTRA_CONFIG_FILE=${VECTRA_CONFIG_FILE:-}
+      # Per-tenant env var overrides (used with YAML config):
+      # - VECTRA_TENANT_PROD_BASE_URL=...
+      # - VECTRA_TENANT_PROD_CLIENT_ID=...
+      # - VECTRA_TENANT_PROD_CLIENT_SECRET=...
+      # - VECTRA_TENANT_STAGING_BASE_URL=...
+      # - VECTRA_TENANT_STAGING_CLIENT_ID=...
+      # - VECTRA_TENANT_STAGING_CLIENT_SECRET=...
+
       # Request Configuration
       - VECTRA_REQUEST_TIMEOUT=${VECTRA_REQUEST_TIMEOUT:-30}
       - VECTRA_RATE_LIMIT_REQUESTS=${VECTRA_RATE_LIMIT_REQUESTS:-100}
       - VECTRA_RATE_LIMIT_PERIOD=${VECTRA_RATE_LIMIT_PERIOD:-60}
-      
+
       # Cache Configuration
       - VECTRA_CACHE_TTL=${VECTRA_CACHE_TTL:-300}
-      
+
       # MCP Server Configuration
       - VECTRA_MCP_TRANSPORT=${VECTRA_MCP_TRANSPORT:-stdio}
       - VECTRA_MCP_HOST=${VECTRA_MCP_HOST:-0.0.0.0}
       - VECTRA_MCP_PORT=${VECTRA_MCP_PORT:-8000}
       - VECTRA_MCP_DEBUG=${VECTRA_MCP_DEBUG:-false}
-      
+
       # Logging Configuration
       - VECTRA_LOG_FILE=${VECTRA_LOG_FILE}
     volumes:
       # Optional: Mount logs directory for persistent logging
       - ./logs:/app/logs:rw
+      # Optional: Mount tenants YAML config for multi-tenant mode
+      - ./tenants.yaml:/app/tenants.yaml:ro
     restart: unless-stopped
     healthcheck:
       test: ["CMD-SHELL", "if [ \"$VECTRA_MCP_TRANSPORT\" = \"stdio\" ]; then echo 'Stdio transport - no HTTP endpoint to check' && exit 0; else curl -f --connect-timeout 5 --max-time 10 http://localhost:${VECTRA_MCP_PORT}/ || exit 1; fi"]

--- a/prompt/prompt.py
+++ b/prompt/prompt.py
@@ -1,28 +1,36 @@
 from typing import Optional, Literal, List, Dict, Any
 from pydantic import Field
 
+
 class VectraMCPPrompts:
     """Vectra AI MCP prompts for threat analysis and investigations."""
-    
-    def __init__(self, vectra_mcp, client):
-        """Initialize with FastMCP instance and Vectra client.
-        
+
+    def __init__(self, vectra_mcp, client, prefix: Optional[str] = None, tenant_label: Optional[str] = None):
+        """Initialize with FastMCP instance, Vectra client, and optional tenant prefix.
+
         Args:
             vectra_mcp: FastMCP server instance
             client: VectraClient instance
+            prefix: Prompt name prefix for multi-tenant mode (e.g., "prod")
+            tenant_label: Human-readable tenant label for descriptions
         """
         self.vectra_mcp = vectra_mcp
         self.client = client
-    
+        self.prefix = prefix
+        self.tenant_label = tenant_label
+
     def register_prompts(self):
         """Register all prompts with the MCP server."""
+        label = f"[{self.tenant_label or self.prefix}] " if self.prefix else ""
+        name_prefix = f"{self.prefix} " if self.prefix else ""
+
         self.vectra_mcp.prompt(
-            name = "Summarize Detection",
-            description = "Get a detailed summary of a specific detection in Vectra AI platform."
+            name=f"{name_prefix}Summarize Detection",
+            description=f"{label}Get a detailed summary of a specific detection in Vectra AI platform."
         )(self.summarize_detection)
         self.vectra_mcp.prompt(
-            name = "Visualize Entity Detections",
-            description = "Visualize realtionship of detections related to a specific entity in Vectra AI platform with a interactive graph."
+            name=f"{name_prefix}Visualize Entity Detections",
+            description=f"{label}Visualize realtionship of detections related to a specific entity in Vectra AI platform with a interactive graph."
         )(self.visualize_entity_detections)
 
     async def summarize_detection(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ requires-python = ">=3.12"
 dependencies = [
     "httpx>=0.28.1",
     "mcp[cli]>=1.12.1",
+    "pyyaml>=6.0",
     "tenacity>=9.1.2",
     "uvicorn>=0.24.0",
 ]

--- a/server.py
+++ b/server.py
@@ -2,6 +2,7 @@
 """Vectra AI MCP Server with support for stdio, SSE, and streamable-http transports."""
 
 import argparse
+import json
 import logging
 import os
 import sys
@@ -11,7 +12,7 @@ import uvicorn
 from mcp.server.fastmcp import FastMCP
 
 from vectra_client import VectraClient
-from config import init_config
+from config import load_configuration, ServerConfiguration
 from utils.logging import setup_logging, get_logger, configure_debug_logging
 
 # Import MCP tools and prompts
@@ -28,14 +29,15 @@ logger = get_logger(__name__)
 class VectraMCPServer:
     """Main server class for the Vectra MCP server."""
 
-    def __init__(self, debug: bool = False):
+    def __init__(self, debug: bool = False, config_file: Optional[str] = None):
         """Initialize the Vectra MCP server.
-        
+
         Args:
             debug: Enable debug logging
+            config_file: Optional path to YAML config file for multi-tenant setup
         """
         self.debug = debug
-        
+
         # Configure logging system
         log_file = os.environ.get('VECTRA_LOG_FILE')
         setup_logging(
@@ -43,17 +45,16 @@ class VectraMCPServer:
             log_file=log_file,
             enable_console=True
         )
-        
+
         if self.debug:
             configure_debug_logging()
             logger.info("Debug logging enabled")
-        
+
         logger.info("Initializing Vectra MCP Server")
-        
-        # Initialize Vectra API client
-        config = init_config()
-        self.client = VectraClient(config)
-        
+
+        # Load configuration (single-tenant or multi-tenant)
+        self.config = load_configuration(config_file)
+
         # Initialize the MCP server
         self.server = FastMCP(
             name="Vectra MCP Server",
@@ -61,49 +62,78 @@ class VectraMCPServer:
             debug=self.debug,
             log_level="DEBUG" if self.debug else "INFO",
         )
-        
-        # Initialize and register tools
+
+        # Create per-tenant clients and register tools
+        self.clients = {}  # tenant_name -> VectraClient
         tool_count = self._register_tools()
         tool_word = "tool" if tool_count == 1 else "tools"
-        
-        logger.info("Initialized server with %d %s", tool_count, tool_word)
-    
+
+        tenant_word = "tenant" if len(self.config.tenants) == 1 else "tenants"
+        logger.info(
+            "Initialized server with %d %s across %d %s",
+            tool_count, tool_word, len(self.config.tenants), tenant_word
+        )
+
     def _register_tools(self) -> int:
         """Register all tools with the MCP server.
-        
+
+        In single-tenant mode, tools are registered without a prefix (backward compatible).
+        In multi-tenant mode, each tenant's tools are prefixed with the tenant name.
+
         Returns:
             int: Number of tools registered
         """
-        # Initialize and register detection tools
-        detection_mcp_tools = DetectionMCPTools(self.server, self.client)
-        detection_mcp_tools.register_tools()
-        
-        # Initialize and register entity tools
-        entity_mcp_tools = EntityMCPTools(self.server, self.client)
-        entity_mcp_tools.register_tools()
-        
-        # Initialize and register investigation tools
-        investigation_mcp_tools = InvestigationMCPTools(self.server, self.client)
-        investigation_mcp_tools.register_tools()
-        
-        # Initialize and register management tools
-        management_mcp_tools = ManagementMCPTools(self.server, self.client)
-        management_mcp_tools.register_tools()
-        
-        # Initialize and register response tools
-        response_mcp_tools = ResponseMCPTools(self.server, self.client)
-        response_mcp_tools.register_tools()
+        if self.config.is_multi_tenant:
+            # Register list_tenants meta-tool
+            self._register_list_tenants_tool()
 
-        # Initialize and register prompts
-        vectra_mcp_prompts = VectraMCPPrompts(self.server, self.client)
-        vectra_mcp_prompts.register_prompts()
-        
+            # Register per-tenant tools
+            for tenant in self.config.tenants:
+                vectra_cfg = self.config.vectra_config_for_tenant(tenant)
+                client = VectraClient(vectra_cfg)
+                self.clients[tenant.name] = client
+
+                tenant_label = f"{tenant.name} ({tenant.base_url})"
+                logger.info("Registering tools for tenant '%s' (%s)", tenant.name, tenant.base_url)
+                self._register_tenant_tools(client, prefix=tenant.name, tenant_label=tenant_label)
+        else:
+            # Single-tenant: no prefix (backward compatible)
+            tenant = self.config.tenants[0]
+            vectra_cfg = self.config.vectra_config_for_tenant(tenant)
+            client = VectraClient(vectra_cfg)
+            self.clients[tenant.name] = client
+            self._register_tenant_tools(client, prefix=None, tenant_label=None)
+
         # Get tool count
         return len(self.server._tool_manager.list_tools())
-    
+
+    def _register_tenant_tools(self, client: VectraClient, prefix: Optional[str], tenant_label: Optional[str]):
+        """Register all tool classes for a single tenant."""
+        DetectionMCPTools(self.server, client, prefix=prefix, tenant_label=tenant_label).register_tools()
+        EntityMCPTools(self.server, client, prefix=prefix, tenant_label=tenant_label).register_tools()
+        InvestigationMCPTools(self.server, client, prefix=prefix, tenant_label=tenant_label).register_tools()
+        ManagementMCPTools(self.server, client, prefix=prefix, tenant_label=tenant_label).register_tools()
+        ResponseMCPTools(self.server, client, prefix=prefix, tenant_label=tenant_label).register_tools()
+        VectraMCPPrompts(self.server, client, prefix=prefix, tenant_label=tenant_label).register_prompts()
+
+    def _register_list_tenants_tool(self):
+        """Register the list_tenants meta-tool (multi-tenant mode only)."""
+        tenant_info = [
+            {"name": t.name, "base_url": t.base_url}
+            for t in self.config.tenants
+        ]
+
+        @self.server.tool(
+            name="list_tenants",
+            description="List all configured Vectra tenants and their tool name prefixes."
+        )
+        async def list_tenants() -> str:
+            """List all configured Vectra tenants and their tool name prefixes."""
+            return json.dumps({"tenants": tenant_info}, indent=2)
+
     def run(self, transport: str = "stdio", host: str = "127.0.0.1", port: int = 8000):
         """Run the MCP server.
-        
+
         Args:
             transport: Transport protocol to use ("stdio", "sse", or "streamable-http")
             host: Host to bind to for HTTP transports (default: 127.0.0.1)
@@ -112,10 +142,10 @@ class VectraMCPServer:
         if transport == "streamable-http":
             # For streamable-http, use uvicorn directly for custom host/port
             logger.info("Starting streamable-http server on %s:%d (MCP endpoint at /mcp)", host, port)
-            
+
             # Get the ASGI app from FastMCP (serves MCP protocol at root path)
             app = self.server.streamable_http_app()
-            
+
             # Run with uvicorn for custom host/port configuration
             uvicorn.run(
                 app,
@@ -126,10 +156,10 @@ class VectraMCPServer:
         elif transport == "sse":
             # For sse, use uvicorn directly for custom host/port (same pattern as streamable-http)
             logger.info("Starting sse server on %s:%d (MCP endpoint at /sse)", host, port)
-            
+
             # Get the ASGI app from FastMCP (serves MCP protocol at root path)
             app = self.server.sse_app()
-            
+
             # Run with uvicorn for custom host/port configuration
             uvicorn.run(
                 app,
@@ -153,17 +183,21 @@ def parse_args():
         # Run with stdio transport (default)
         python server.py
         python server.py --transport stdio
-        
+
         # Run with SSE transport (MCP endpoint at http://host:port/)
         python server.py --transport sse
         python server.py --transport sse --host 0.0.0.0 --port 8080
-        
+
         # Run with streamable-http transport (MCP endpoint at http://host:port/)
         python server.py --transport streamable-http
         python server.py --transport streamable-http --host 0.0.0.0 --port 8000
+
+        # Run with multi-tenant YAML config
+        python server.py --config tenants.yaml
+        python server.py -c tenants.yaml --transport sse
         """
     )
-    
+
     # Transport options
     parser.add_argument(
         "--transport",
@@ -172,7 +206,15 @@ def parse_args():
         default=os.environ.get("VECTRA_MCP_TRANSPORT", "stdio"),
         help="Transport protocol to use (default: stdio, env: VECTRA_MCP_TRANSPORT)"
     )
-    
+
+    # Configuration file
+    parser.add_argument(
+        "--config",
+        "-c",
+        default=os.environ.get("VECTRA_CONFIG_FILE", None),
+        help="Path to YAML configuration file for multi-tenant setup (env: VECTRA_CONFIG_FILE)"
+    )
+
     # Debug mode
     parser.add_argument(
         "--debug",
@@ -181,14 +223,14 @@ def parse_args():
         default=os.environ.get("VECTRA_MCP_DEBUG", "").lower() == "true",
         help="Enable debug logging (env: VECTRA_MCP_DEBUG)"
     )
-    
+
     # HTTP transport configuration
     parser.add_argument(
         "--host",
         default=os.environ.get("VECTRA_MCP_HOST", "0.0.0.0"),
         help="Host to bind to for HTTP transports (default: 0.0.0.0, env: VECTRA_MCP_HOST)"
     )
-    
+
     parser.add_argument(
         "--port",
         "-p",
@@ -196,7 +238,7 @@ def parse_args():
         default=int(os.environ.get("VECTRA_MCP_PORT", "8000")),
         help="Port to listen on for HTTP transports (default: 8000, env: VECTRA_MCP_PORT)"
     )
-    
+
     return parser.parse_args()
 
 
@@ -204,10 +246,10 @@ def main():
     """Main entry point for the Vectra MCP server."""
     # Parse command line arguments (includes environment variable defaults)
     args = parse_args()
-    
+
     try:
         # Create and run the server
-        server = VectraMCPServer(debug=args.debug)
+        server = VectraMCPServer(debug=args.debug, config_file=args.config)
         logger.info("Starting server with %s transport", args.transport)
         server.run(args.transport, host=args.host, port=args.port)
     except RuntimeError as e:

--- a/tenants.yaml.example
+++ b/tenants.yaml.example
@@ -1,0 +1,41 @@
+# Multi-tenant configuration for Vectra MCP Server
+#
+# Each tenant gets its own set of tools, prefixed with the tenant name.
+# For example, a tenant named "prod" will have tools like:
+#   prod_list_detections, prod_get_detection_details, etc.
+#
+# A "list_tenants" meta-tool is automatically added to discover all tenants.
+#
+# Environment variable overrides (useful for Docker / Kubernetes secrets):
+#   VECTRA_TENANT_<NAME_UPPER>_BASE_URL
+#   VECTRA_TENANT_<NAME_UPPER>_CLIENT_ID
+#   VECTRA_TENANT_<NAME_UPPER>_CLIENT_SECRET
+#   VECTRA_TENANT_<NAME_UPPER>_API_VERSION
+#   VECTRA_TENANT_<NAME_UPPER>_OAUTH_TOKEN_URL
+#   VECTRA_TENANT_<NAME_UPPER>_REQUEST_TIMEOUT
+#   VECTRA_TENANT_<NAME_UPPER>_RATE_LIMIT_REQUESTS
+#   VECTRA_TENANT_<NAME_UPPER>_RATE_LIMIT_PERIOD
+#   VECTRA_TENANT_<NAME_UPPER>_CACHE_TTL
+#
+# Example: VECTRA_TENANT_PROD_CLIENT_SECRET=<secret> overrides client_secret for "prod"
+#
+# To use this file:
+#   python server.py --config tenants.yaml
+#   # or set: VECTRA_CONFIG_FILE=tenants.yaml
+
+tenants:
+  - name: prod
+    base_url: https://prod-tenant.uw2.portal.vectra.ai
+    client_id: "<prod-client-id>"
+    client_secret: "<prod-client-secret>"
+    # Optional per-tenant overrides (defaults shown):
+    # api_version: v3.4
+    # request_timeout: 30
+    # rate_limit_requests: 100
+    # rate_limit_period: 60
+    # cache_ttl: 300
+
+  - name: staging
+    base_url: https://staging-tenant.uw2.portal.vectra.ai
+    client_id: "<staging-client-id>"
+    client_secret: "<staging-client-secret>"

--- a/tool/base.py
+++ b/tool/base.py
@@ -1,0 +1,53 @@
+"""Base class for MCP tool registration with multi-tenant prefix support."""
+
+import functools
+from typing import Optional
+
+
+class BaseMCPTools:
+    """Base class providing prefixed tool registration for multi-tenancy."""
+
+    def __init__(self, vectra_mcp, client, prefix: Optional[str] = None, tenant_label: Optional[str] = None):
+        """Initialize with FastMCP instance, Vectra client, and optional tenant prefix.
+
+        Args:
+            vectra_mcp: FastMCP server instance
+            client: VectraClient instance
+            prefix: Tool name prefix for multi-tenant mode (e.g., "prod")
+            tenant_label: Human-readable tenant label for descriptions (e.g., "prod (https://prod.vectra.ai)")
+        """
+        self.vectra_mcp = vectra_mcp
+        self.client = client
+        self.prefix = prefix
+        self.tenant_label = tenant_label
+
+    def _register_tool(self, method):
+        """Register a tool with optional tenant prefix on the name and description.
+
+        In single-tenant mode (prefix=None), this behaves identically to
+        ``self.vectra_mcp.tool()(method)`` -- no name or description override.
+
+        In multi-tenant mode, the tool name becomes ``{prefix}_{method.__name__}``
+        and the first line of the docstring is prefixed with ``[{tenant_label}]``.
+        """
+        if self.prefix:
+            name = f"{self.prefix}_{method.__name__}"
+            # Build a prefixed description from the docstring's first line
+            description = None
+            if method.__doc__:
+                first_line = method.__doc__.strip().split("\n")[0].strip()
+                description = f"[{self.tenant_label or self.prefix}] {first_line}"
+
+            # We need a wrapper with a distinct identity so FastMCP doesn't
+            # reject duplicate registrations of the same function object.
+            @functools.wraps(method)
+            async def wrapper(*args, **kwargs):
+                return await method(*args, **kwargs)
+
+            kwargs = {"name": name}
+            if description:
+                kwargs["description"] = description
+            self.vectra_mcp.tool(**kwargs)(wrapper)
+        else:
+            # Single-tenant: register as-is (backward compatible)
+            self.vectra_mcp.tool()(method)

--- a/tool/detection_tools.py
+++ b/tool/detection_tools.py
@@ -169,10 +169,16 @@ class DetectionMCPTools(BaseMCPTools):
             str: Count of detections matching the criteria.
         """
         params = locals().copy()
-        exclude_params = {'self', 'start_date', 'end_date'}
+        exclude_params = {'self', 'start_date', 'end_date', 'detection_name'}
 
         search_params = {k: v for k, v in params.items()
                    if v is not None and k not in exclude_params}
+
+        if detection_name:
+            search_params['detection_type'] = detection_name
+
+        # Only fetch 1 result since we just need the count from the response
+        search_params['page_size'] = 1
 
         # Add date filters if provided
         start_date, end_date = validate_date_range(start_date, end_date)
@@ -203,13 +209,12 @@ class DetectionMCPTools(BaseMCPTools):
             Exception: If retrieval fails.
         """
         try:
-            pcap_data = await self.client.get_detection_pcap(detection_id)
+            pcap_bytes = await self.client.get_detection_pcap(detection_id)
 
-            if not pcap_data:
+            if not pcap_bytes:
                 return f"No pcap data found for detection ID {detection_id}."
-            
-            # Encode binary content as base64
-            encoded_content = base64.b64encode(pcap_data).decode('utf-8')
+
+            encoded_content = base64.b64encode(pcap_bytes).decode('utf-8')
 
             return f"PCAP data for detection ID {detection_id}:\n{encoded_content}"
 
@@ -329,15 +334,14 @@ class DetectionMCPTools(BaseMCPTools):
                 for dets in detections
             ]
 
+        if limit and len(detection_list) > limit:
+            detection_list = detection_list[:limit]
+
         response = {"detection_count": total_count, "detections": detection_list}
-        
-        if limit:
-            if total_count > limit:
-            # Limit the number of detections returned to reduce response size
-                detections = detections[:limit]
-                response["note"] = f"Results limited to {limit} detections. Total detections found: {total_count}."
-                response["detections"] = detection_list
-            
+
+        if limit and total_count > limit:
+            response["note"] = f"Results limited to {limit} detections. Total detections found: {total_count}."
+
         return json.dumps(response, indent=2)
     
     async def get_detection_summary(

--- a/tool/detection_tools.py
+++ b/tool/detection_tools.py
@@ -6,30 +6,22 @@ import json
 import base64
 
 from utils.validators import validate_date_range
+from tool.base import BaseMCPTools
 
-class DetectionMCPTools:
+
+class DetectionMCPTools(BaseMCPTools):
     """MCP tools for detection analysis and management."""
-    
-    def __init__(self, vectra_mcp, client):
-        """Initialize with FastMCP instance and Vectra client.
-        
-        Args:
-            vectra_mcp: FastMCP server instance
-            client: VectraClient instance
-        """
-        self.vectra_mcp = vectra_mcp
-        self.client = client
-    
+
     def register_tools(self):
         """Register all detection tools with the MCP server."""
-        self.vectra_mcp.tool()(self.list_detection_ids)
-        self.vectra_mcp.tool()(self.list_detections_with_basic_info)
-        self.vectra_mcp.tool()(self.list_detections_with_details)
-        self.vectra_mcp.tool()(self.list_entity_detections)
-        self.vectra_mcp.tool()(self.get_detection_count)
-        self.vectra_mcp.tool()(self.get_detection_details)
-        self.vectra_mcp.tool()(self.get_detection_summary)
-        self.vectra_mcp.tool()(self.get_detection_pcap)
+        self._register_tool(self.list_detection_ids)
+        self._register_tool(self.list_detections_with_basic_info)
+        self._register_tool(self.list_detections_with_details)
+        self._register_tool(self.list_entity_detections)
+        self._register_tool(self.get_detection_count)
+        self._register_tool(self.get_detection_details)
+        self._register_tool(self.get_detection_summary)
+        self._register_tool(self.get_detection_pcap)
     
     async def get_detection_details(
         self,

--- a/tool/entity_tools.py
+++ b/tool/entity_tools.py
@@ -4,26 +4,19 @@ from typing import Literal, Annotated
 from pydantic import Field, IPvAnyAddress
 import json
 
-class EntityMCPTools:
+from tool.base import BaseMCPTools
+
+
+class EntityMCPTools(BaseMCPTools):
     """MCP tools for entity (host or account) analysis and management."""
-    
-    def __init__(self, vectra_mcp, client):
-        """Initialize with FastMCP instance and Vectra client.
-        
-        Args:
-            vectra_mcp: FastMCP server instance
-            client: VectraClient instance
-        """
-        self.vectra_mcp = vectra_mcp
-        self.client = client
-    
+
     def register_tools(self):
         """Register all entity tools with the MCP server."""
-        self.vectra_mcp.tool()(self.list_entities)
-        self.vectra_mcp.tool()(self.lookup_entity_info_by_name)
-        self.vectra_mcp.tool()(self.lookup_host_by_ip)
-        self.vectra_mcp.tool()(self.get_host_details)
-        self.vectra_mcp.tool()(self.get_account_details)
+        self._register_tool(self.list_entities)
+        self._register_tool(self.lookup_entity_info_by_name)
+        self._register_tool(self.lookup_host_by_ip)
+        self._register_tool(self.get_host_details)
+        self._register_tool(self.get_account_details)
     
     async def list_entities(
         self,

--- a/tool/investigation_tools.py
+++ b/tool/investigation_tools.py
@@ -74,7 +74,7 @@ class InvestigationMCPTools(BaseMCPTools):
         """
         try:
             assignments = await self.client.get_assignments(
-                assignee = user_id,
+                assignees = user_id,
                 resolved = resolved
                 )
             if assignments is None:
@@ -184,7 +184,7 @@ class InvestigationMCPTools(BaseMCPTools):
 
         try:
             # Create the assignment
-            assignment = await self.client.delete_assignment(assignment_data)
+            assignment = await self.client.create_assignment(assignment_data)
             assignment_id = assignment.get("assignment").get("id")
             
             # Return assignment details

--- a/tool/investigation_tools.py
+++ b/tool/investigation_tools.py
@@ -5,30 +5,22 @@ from pydantic import Field
 import json
 
 from utils.validators import validate_date_range
+from tool.base import BaseMCPTools
 
-class InvestigationMCPTools:
+
+class InvestigationMCPTools(BaseMCPTools):
     """MCP tools for investigations."""
-    
-    def __init__(self, vectra_mcp, client):
-        """Initialize with FastMCP instance and Vectra client.
-        
-        Args:
-            vectra_mcp: FastMCP server instance
-            client: VectraClient instance
-        """
-        self.vectra_mcp = vectra_mcp
-        self.client = client
-    
+
     def register_tools(self):
         """Register all investigation tools with the MCP server."""
-        self.vectra_mcp.tool()(self.create_assignment)
-        self.vectra_mcp.tool()(self.list_assignments)
-        self.vectra_mcp.tool()(self.list_assignments_for_user)
-        self.vectra_mcp.tool()(self.delete_assignment)
-        self.vectra_mcp.tool()(self.get_assignment_detail_by_id)
-        self.vectra_mcp.tool()(self.get_assignment_for_entity)
-        self.vectra_mcp.tool()(self.create_entity_note)
-        self.vectra_mcp.tool()(self.mark_detection_fixed)
+        self._register_tool(self.create_assignment)
+        self._register_tool(self.list_assignments)
+        self._register_tool(self.list_assignments_for_user)
+        self._register_tool(self.delete_assignment)
+        self._register_tool(self.get_assignment_detail_by_id)
+        self._register_tool(self.get_assignment_for_entity)
+        self._register_tool(self.create_entity_note)
+        self._register_tool(self.mark_detection_fixed)
 
     async def list_assignments(
             self,

--- a/tool/management_tools.py
+++ b/tool/management_tools.py
@@ -77,7 +77,7 @@ class ManagementMCPTools(BaseMCPTools):
             user_count = len(user_list)
 
             # Return formatted JSON response
-            return json.dumps({"uer_couclnt": user_count, "user_list": user_list}, indent=2)
+            return json.dumps({"user_count": user_count, "user_list": user_list}, indent=2)
             
         except Exception as e:
             raise Exception(f"Failed to list users : {str(e)}")

--- a/tool/management_tools.py
+++ b/tool/management_tools.py
@@ -5,23 +5,15 @@ from pydantic import Field
 import json
 
 from utils.validators import validate_date_range
+from tool.base import BaseMCPTools
 
-class ManagementMCPTools:
+
+class ManagementMCPTools(BaseMCPTools):
     """MCP tools for Vectra AI platform management."""
-    
-    def __init__(self, vectra_mcp, client):
-        """Initialize with FastMCP instance and Vectra client.
-        
-        Args:
-            vectra_mcp: FastMCP server instance
-            client: VectraClient instance
-        """
-        self.vectra_mcp = vectra_mcp
-        self.client = client
-    
+
     def register_tools(self):
         """Register all platform management tools with the MCP server."""
-        self.vectra_mcp.tool()(self.list_platform_users)
+        self._register_tool(self.list_platform_users)
 
     async def list_platform_users(
         self,

--- a/tool/response_tools.py
+++ b/tool/response_tools.py
@@ -2,22 +2,15 @@
 
 import json
 
-class ResponseMCPTools:
+from tool.base import BaseMCPTools
+
+
+class ResponseMCPTools(BaseMCPTools):
     """MCP tools for response actions."""
-    
-    def __init__(self, vectra_mcp, client):
-        """Initialize with FastMCP instance and Vectra client.
-        
-        Args:
-            vectra_mcp: FastMCP server instance
-            client: VectraClient instance
-        """
-        self.vectra_mcp = vectra_mcp
-        self.client = client
-    
+
     def register_tools(self):
         """Register all response tools with the MCP server."""
-        self.vectra_mcp.tool()(self.list_lockdown_entities)
+        self._register_tool(self.list_lockdown_entities)
 
     async def list_lockdown_entities(
         self,

--- a/uv.lock
+++ b/uv.lock
@@ -310,6 +310,52 @@ wheels = [
 ]
 
 [[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
 name = "referencing"
 version = "0.36.2"
 source = { registry = "https://pypi.org/simple" }
@@ -520,6 +566,7 @@ source = { virtual = "." }
 dependencies = [
     { name = "httpx" },
     { name = "mcp", extra = ["cli"] },
+    { name = "pyyaml" },
     { name = "tenacity" },
     { name = "uvicorn" },
 ]
@@ -528,6 +575,7 @@ dependencies = [
 requires-dist = [
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.12.1" },
+    { name = "pyyaml", specifier = ">=6.0" },
     { name = "tenacity", specifier = ">=9.1.2" },
     { name = "uvicorn", specifier = ">=0.24.0" },
 ]

--- a/vectra_client.py
+++ b/vectra_client.py
@@ -873,7 +873,7 @@ class VectraClient:
 
         headers = {
             "Authorization": f"Bearer {access_token}",
-            "Accept": "application/octet-stream",
+            "Accept": "*/*",
             "User-Agent": "VectraMCPServer/1.0.0",
         }
 
@@ -886,6 +886,13 @@ class VectraClient:
                 raise VectraNotFoundError(
                     f"No PCAP available for detection {detection_id}",
                     status_code=404,
+                )
+            if response.status_code == 406:
+                raise VectraNotFoundError(
+                    f"No PCAP data available for detection {detection_id}. "
+                    f"PCAPs are only generated for network-based detections "
+                    f"(not cloud/log-based detections such as M365, Azure AD, or AWS).",
+                    status_code=406,
                 )
             if response.status_code == 401:
                 raise VectraAuthenticationError(

--- a/vectra_client.py
+++ b/vectra_client.py
@@ -861,9 +861,48 @@ class VectraClient:
         return await self._make_request("GET", "vectra-match/available-devices")
     
     # Vectra pcap endpoints
-    async def get_detection_pcap(self, detection_id) -> Dict[str, Any]:
-        """Get Vectra Match statistics."""
-        return await self._make_request("GET", f"detections/{detection_id}/pcap")
+    async def get_detection_pcap(self, detection_id: int) -> bytes:
+        """Download PCAP file for a specific detection.
+
+        Returns raw bytes so callers can base64-encode or save directly.
+        Raises VectraAPIError / VectraNotFoundError on failure.
+        """
+        await self.rate_limiter.acquire()
+        access_token = await self.token_manager.get_access_token()
+        url = urljoin(self.config.api_base_url + "/", f"detections/{detection_id}/pcap")
+
+        headers = {
+            "Authorization": f"Bearer {access_token}",
+            "Accept": "application/octet-stream",
+            "User-Agent": "VectraMCPServer/1.0.0",
+        }
+
+        self.logger.debug("Downloading PCAP for detection %s", detection_id)
+
+        try:
+            response = await self.client.request("GET", url, headers=headers)
+
+            if response.status_code == 404:
+                raise VectraNotFoundError(
+                    f"No PCAP available for detection {detection_id}",
+                    status_code=404,
+                )
+            if response.status_code == 401:
+                raise VectraAuthenticationError(
+                    "Authentication failed - check credentials", status_code=401
+                )
+            if not response.is_success:
+                raise VectraAPIError(
+                    f"PCAP download failed with status {response.status_code}",
+                    status_code=response.status_code,
+                )
+
+            return response.content
+
+        except (VectraAPIError, VectraAuthenticationError, VectraNotFoundError):
+            raise
+        except httpx.RequestError as e:
+            raise VectraAPIError(f"Request error downloading PCAP: {e}")
     
     # Vectra lockdown endpoints
     async def get_lockdown_entities(self) -> Dict[str, Any]:


### PR DESCRIPTION
## Summary

- **Multi-tenant support**: Added YAML-based multi-tenant configuration allowing a single MCP server instance to manage multiple Vectra tenants simultaneously. Each tenant's tools are registered with a name prefix (e.g. `cyberrange_get_detection_details`), and a `list_tenants` meta-tool is available in multi-tenant mode. Backward-compatible single-tenant mode is preserved.
- **Bug fixes** identified during E2E testing across both tenants:
  - **`get_detection_pcap` crash** (High): Fixed `TypeError: a bytes-like object is required, not 'dict'` — the generic `_make_request` always returned a dict, but PCAP needs raw bytes. Added a dedicated binary download method in `VectraClient` with proper error handling (404, 406, 401). Added explicit 406 handling with a message explaining PCAPs are only available for network-based detections.
  - **`list_detections_with_basic_info` ignoring `limit`** (High): The limit logic sliced the wrong list and then reassigned the full unsliced list. Fixed to properly truncate the projected `detection_list` before building the response.
  - **`create_assignment` calling wrong client method** (High): Copy-paste bug — was calling `self.client.delete_assignment(assignment_data)` instead of `self.client.create_assignment(assignment_data)`, producing a mangled DELETE URL and returning 404.
  - **`list_assignments_for_user` HTTP 400** (Medium): Wrong query parameter name — `assignee` changed to `assignees` to match the Vectra v3.x API.
  - **`get_detection_count` timeout on large tenants** (Medium): Added `page_size=1` since only the count is needed (not results). Also fixed `detection_name` leaking as an invalid query parameter (missing from `exclude_params`).
  - **`list_platform_users` field typo** (Low): Fixed `"uer_couclnt"` → `"user_count"` in the JSON response.

## Test plan

- [ ] Verify `list_detections_with_basic_info` respects the `limit` parameter (e.g. `limit=3` returns exactly 3 results)
- [ ] Verify `get_detection_count` completes within a few seconds on large tenants (cyberrange)
- [ ] Verify `get_detection_pcap` returns a clear message for cloud-based detections (406) and works for network-based detections with PCAPs
- [ ] Verify `create_assignment` successfully creates an assignment (POST, not DELETE)
- [ ] Verify `list_assignments_for_user` returns assignments for a valid user ID without HTTP 400
- [ ] Verify `list_platform_users` returns `"user_count"` field name
- [ ] Verify single-tenant mode still works (no config file, env vars only)
- [ ] Verify multi-tenant mode works with `tenants.yaml` config


Made with [Cursor](https://cursor.com)