### PR TITLE
Add platform health MCP tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ An MCP server that connects AI assistants to your Vectra AI security platform, e
 * Correlate and analyze security data using prompts
 * Dynamically build advanced visulizations for analysis
 * Generate investigation reports from natural language
+* Retrieve complete platform health or a specific health category, including EDR,
+  external connector, and Network Brain status
 
 # Setup - uvx (Recommended for End Users)
 

--- a/src/vectra_mcp_server/tool/management_tools.py
+++ b/src/vectra_mcp_server/tool/management_tools.py
@@ -14,6 +14,140 @@ class ManagementMCPTools(BaseMCPTools):
     def register_tools(self):
         """Register all platform management tools with the MCP server."""
         self._register_tool(self.list_platform_users)
+        self._register_tool(self.get_platform_health)
+
+    async def get_platform_health(
+        self,
+        health_type: Annotated[
+            Literal[
+                "all",
+                "platform",
+                "edr",
+                "edr_details",
+                "external_connectors",
+                "external_connectors_details",
+                "network_brain_ping",
+            ],
+            Field(
+                description=(
+                    "Health information to fetch. Defaults to all, which returns platform, "
+                    "EDR, external connector, and Network Brain health information."
+                )
+            ),
+        ] = "all",
+        connector_type: Annotated[
+            str | None,
+            Field(
+                description=(
+                    "Comma-separated external connector types to include in detailed "
+                    "connector health. Valid values: active_directory, azure_ad_lockdown, "
+                    "aws, azure, google_cloud, reverse_lookup_dns, siem, vcenter, "
+                    "windows_event_log_ingestion, zscaler_private_access."
+                )
+            ),
+        ] = None,
+        edr_type: Annotated[
+            str | None,
+            Field(
+                description=(
+                    "Optional comma-separated EDR type filter for detailed EDR health. "
+                    "Passed directly to Vectra's edr_type query parameter."
+                )
+            ),
+        ] = None,
+        live: Annotated[
+            bool | None,
+            Field(
+                description=(
+                    "For detailed EDR and external-connector health, request a live "
+                    "refresh instead of cached health information."
+                )
+            ),
+        ] = None,
+    ) -> str:
+        """Get platform health, a specific health category, or complete diagnostics."""
+        self._validate_health_filters(health_type, connector_type, edr_type, live)
+
+        requests = {
+            "platform": self.client.get_health,
+            "edr": self.client.get_edr_health,
+            "edr_details": lambda: self.client.get_edr_health_details(
+                edr_type=edr_type, live=live
+            ),
+            "external_connectors": self.client.get_external_connectors_health,
+            "external_connectors_details": lambda: self.client.get_external_connectors_health_details(
+                connector_type=connector_type, live=live
+            ),
+            "network_brain_ping": self.client.ping_network_brain,
+        }
+
+        if health_type != "all":
+            try:
+                return json.dumps(await requests[health_type](), indent=2)
+            except Exception as exc:
+                raise Exception(
+                    f"Failed to fetch {health_type} health information: {exc}"
+                ) from exc
+
+        results = {}
+        errors = {}
+        for category, request in requests.items():
+            try:
+                results[category] = await request()
+            except Exception as exc:
+                error = {"type": type(exc).__name__, "message": str(exc)}
+                if getattr(exc, "status_code", None) is not None:
+                    error["status_code"] = exc.status_code
+                errors[category] = error
+
+        response = {"results": results}
+        if errors:
+            response["errors"] = errors
+        return json.dumps(response, indent=2)
+
+    @staticmethod
+    def _validate_health_filters(
+        health_type: str,
+        connector_type: str | None,
+        edr_type: str | None,
+        live: bool | None,
+    ) -> None:
+        """Validate filters before dispatching health requests."""
+        connector_detail_types = {"all", "external_connectors_details"}
+        edr_detail_types = {"all", "edr_details"}
+        detail_types = connector_detail_types | edr_detail_types
+
+        if connector_type and health_type not in connector_detail_types:
+            raise ValueError(
+                "connector_type is only valid for external_connectors_details or all"
+            )
+        if edr_type and health_type not in edr_detail_types:
+            raise ValueError("edr_type is only valid for edr_details or all")
+        if live is not None and health_type not in detail_types:
+            raise ValueError(
+                "live is only valid for edr_details, external_connectors_details, or all"
+            )
+
+        valid_connector_types = {
+            "active_directory",
+            "azure_ad_lockdown",
+            "aws",
+            "azure",
+            "google_cloud",
+            "reverse_lookup_dns",
+            "siem",
+            "vcenter",
+            "windows_event_log_ingestion",
+            "zscaler_private_access",
+        }
+        if connector_type:
+            requested_types = {item.strip() for item in connector_type.split(",") if item.strip()}
+            invalid_types = requested_types - valid_connector_types
+            if not requested_types or invalid_types:
+                raise ValueError(
+                    "Invalid connector_type values: "
+                    + ", ".join(sorted(invalid_types or {connector_type}))
+                )
 
     async def list_platform_users(
         self,
@@ -81,5 +215,3 @@ class ManagementMCPTools(BaseMCPTools):
             
         except Exception as e:
             raise Exception(f"Failed to list users : {str(e)}")
-
-    

--- a/src/vectra_mcp_server/vectra_client.py
+++ b/src/vectra_mcp_server/vectra_client.py
@@ -621,8 +621,46 @@ class VectraClient:
     
     # Health endpoints
     async def get_health(self) -> Dict[str, Any]:
-        """Get system health status."""
+        """Get overall platform health status."""
         return await self._make_request("GET", "health")
+
+    async def get_edr_health(self) -> Dict[str, Any]:
+        """Get summary health status for EDR integrations."""
+        return await self._make_request("GET", "health/edr")
+
+    async def get_edr_health_details(
+        self,
+        edr_type: Optional[str] = None,
+        live: Optional[bool] = None,
+    ) -> Dict[str, Any]:
+        """Get detailed health status for EDR integrations."""
+        params = {k: v for k, v in {
+            "edr_type": edr_type,
+            "live": live,
+        }.items() if v is not None}
+        return await self._make_request("GET", "health/edr/details", params=params)
+
+    async def get_external_connectors_health(self) -> Dict[str, Any]:
+        """Get summary health status for external connectors."""
+        return await self._make_request("GET", "health/external_connectors")
+
+    async def get_external_connectors_health_details(
+        self,
+        connector_type: Optional[str] = None,
+        live: Optional[bool] = None,
+    ) -> Dict[str, Any]:
+        """Get detailed health status for external connectors."""
+        params = {k: v for k, v in {
+            "connector_type": connector_type,
+            "live": live,
+        }.items() if v is not None}
+        return await self._make_request(
+            "GET", "health/external_connectors/details", params=params
+        )
+
+    async def ping_network_brain(self) -> Dict[str, Any]:
+        """Ping the Network Brain health endpoint."""
+        return await self._make_request("GET", "health/network_brain/ping")
     
     # Notes endpoints
     async def add_entity_note(self, entity_id: int, type: str, note: str) -> Dict[str, Any]:

--- a/tests/test_health_client.py
+++ b/tests/test_health_client.py
@@ -1,0 +1,37 @@
+from unittest.mock import AsyncMock
+
+import pytest
+
+from vectra_mcp_server.vectra_client import VectraClient
+
+
+@pytest.mark.parametrize(
+    ("method_name", "kwargs", "endpoint", "params"),
+    [
+        ("get_health", {}, "health", None),
+        ("get_edr_health", {}, "health/edr", None),
+        (
+            "get_edr_health_details",
+            {"edr_type": "crowdstrike", "live": True},
+            "health/edr/details",
+            {"edr_type": "crowdstrike", "live": True},
+        ),
+        ("get_external_connectors_health", {}, "health/external_connectors", None),
+        (
+            "get_external_connectors_health_details",
+            {"connector_type": "aws", "live": False},
+            "health/external_connectors/details",
+            {"connector_type": "aws", "live": False},
+        ),
+        ("ping_network_brain", {}, "health/network_brain/ping", None),
+    ],
+)
+async def test_health_client_methods_use_expected_endpoint(method_name, kwargs, endpoint, params):
+    client = VectraClient.__new__(VectraClient)
+    client._make_request = AsyncMock(return_value={"ok": True})
+
+    assert await getattr(client, method_name)(**kwargs) == {"ok": True}
+    if params is None:
+        client._make_request.assert_awaited_once_with("GET", endpoint)
+    else:
+        client._make_request.assert_awaited_once_with("GET", endpoint, params=params)

--- a/tests/test_health_tools.py
+++ b/tests/test_health_tools.py
@@ -1,0 +1,83 @@
+import json
+from unittest.mock import AsyncMock
+
+import pytest
+
+from vectra_mcp_server.tool.management_tools import ManagementMCPTools
+from vectra_mcp_server.vectra_client import VectraAPIError
+
+
+class FakeHealthClient:
+    def __init__(self):
+        self.get_health = AsyncMock(return_value={"platform": "healthy"})
+        self.get_edr_health = AsyncMock(return_value={"edr": "healthy"})
+        self.get_edr_health_details = AsyncMock(return_value={"edr_details": "healthy"})
+        self.get_external_connectors_health = AsyncMock(
+            return_value={"external_connectors": "healthy"}
+        )
+        self.get_external_connectors_health_details = AsyncMock(
+            return_value={"external_connector_details": "healthy"}
+        )
+        self.ping_network_brain = AsyncMock(return_value={"network_brain": "healthy"})
+
+
+def make_tools(client):
+    return ManagementMCPTools(vectra_mcp=None, client=client)
+
+
+async def test_get_platform_health_routes_to_requested_category():
+    client = FakeHealthClient()
+
+    result = json.loads(
+        await make_tools(client).get_platform_health(
+            health_type="external_connectors_details",
+            connector_type="aws,azure",
+            live=True,
+        )
+    )
+
+    assert result == {"external_connector_details": "healthy"}
+    client.get_external_connectors_health_details.assert_awaited_once_with(
+        connector_type="aws,azure", live=True
+    )
+    client.get_health.assert_not_awaited()
+
+
+async def test_get_platform_health_all_returns_partial_results_and_errors():
+    client = FakeHealthClient()
+    client.get_edr_health.side_effect = VectraAPIError("not authorized", status_code=403)
+
+    result = json.loads(await make_tools(client).get_platform_health())
+
+    assert result["results"]["platform"] == {"platform": "healthy"}
+    assert "edr" not in result["results"]
+    assert result["errors"]["edr"] == {
+        "type": "VectraAPIError",
+        "message": "not authorized",
+        "status_code": 403,
+    }
+    client.get_edr_health_details.assert_awaited_once_with(edr_type=None, live=None)
+    client.get_external_connectors_health_details.assert_awaited_once_with(
+        connector_type=None, live=None
+    )
+
+
+@pytest.mark.parametrize(
+    ("health_type", "connector_type", "edr_type", "live"),
+    [
+        ("platform", "aws", None, None),
+        ("edr", None, "crowdstrike", None),
+        ("network_brain_ping", None, None, True),
+        ("external_connectors_details", "not_a_connector", None, None),
+    ],
+)
+async def test_get_platform_health_rejects_inapplicable_or_invalid_filters(
+    health_type, connector_type, edr_type, live
+):
+    with pytest.raises(ValueError):
+        await make_tools(FakeHealthClient()).get_platform_health(
+            health_type=health_type,
+            connector_type=connector_type,
+            edr_type=edr_type,
+            live=live,
+        )


### PR DESCRIPTION
  ## Summary

  Adds a unified `get_platform_health` MCP tool for retrieving Vectra platform health information.

  It supports:

  - Overall platform health
  - EDR health and detailed EDR health
  - External connector health and detailed connector health
  - Network Brain ping
  - Complete diagnostics across all supported endpoints

  ## Behavior

  - `health_type="all"` returns successful endpoint responses plus structured per-endpoint errors, allowing
  partial results when a capability is unavailable or unauthorized.
  - Detail requests support `live` refresh, external connector filtering, and EDR-type filtering.
  - Multi-tenant tool-prefix behavior remains unchanged.

  ## Validation

  - Added client endpoint-routing tests.
  - Added tool routing, validation, and aggregate partial-failure tests.
  - `12 passed` via `pytest`.
  - Verified FastMCP registers `get_platform_health`.

  ## Notes

  - The unrelated `uv.lock` change is intentionally excluded from this PR.