### PR TITLE
fix: :latest follows releases, not the default branch

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -50,7 +50,13 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
-            type=raw,value=latest,enable={{is_default_branch}}
+            # `latest` follows RELEASES, not the default branch. It was
+            # enable={{is_default_branch}}, so every push to main moved it — and
+            # since the README only ever showed :latest, that made any merge to
+            # main an immediate release to every Docker deployment, with no
+            # version bump involved. PyPI was already gated this way; this makes
+            # the two channels agree, so a tag is the single release action.
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
 
       - name: Build Docker image
         uses: docker/build-push-action@v5
@@ -168,7 +174,20 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
-            type=raw,value=latest,enable={{is_default_branch}}
+            # See the note in the build-and-test job: `latest` tracks tags, not
+            # main. This is the job that actually pushes, so this is the line
+            # that decides what users receive.
+            #
+            # RELEASE PROCEDURE — push the tag by hand:
+            #     git tag -a v0.4.0 -m "Release v0.4.0" && git push origin v0.4.0
+            #
+            # Do NOT rely on publish-pypi.yml's auto-tag-on-main-push path for a
+            # Docker release. That job creates the tag with GITHUB_TOKEN, and
+            # GitHub does not trigger workflows from GITHUB_TOKEN-authored events
+            # (it prevents recursion). The tag appears, PyPI publishes, and this
+            # workflow never runs — so no :latest and no :<version> image. A
+            # human-pushed tag triggers both.
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
 
       - name: Build and push Docker image
         id: push

--- a/README.md
+++ b/README.md
@@ -327,7 +327,21 @@ cp .env.example .env
 ```
 Then edit the `.env` file with your actual Vectra AI Platform credentials.
 
-2. **Run with pre-built image:**
+2. **Choose a tag.**
+
+| Tag | Moves when | Use for |
+|---|---|---|
+| `:0.3.2` | never | **production** — pin to an exact release |
+| `:0.3` | a new 0.3.x release | production, floating within a minor line |
+| `:latest` | a new release is tagged | evaluation, or when you want the newest release |
+| `:main` | every push to `main` | tracking unreleased work; expect breakage |
+
+Examples below use `:latest`. **For production, replace it with an exact
+version.** `:latest` tracked the `main` branch until 0.4.0, so any merge landed
+in deployments on the next pull; it now moves only on a tagged release, but a
+pinned tag is still the only one that never changes under you.
+
+3. **Run with pre-built image:**
 
 #### Streamable HTTP Transport (Recommended for Production)
 ```bash
@@ -365,7 +379,7 @@ docker run -d \
   ghcr.io/vectra-ai-research/vectra-ai-mcp-server:latest
 ```
 
-3. **Or use Docker Compose (Alternative):**
+4. **Or use Docker Compose (Alternative):**
 
 Create a `docker-compose.yml` file:
 ```yaml


### PR DESCRIPTION
docker.yml had enable={{is_default_branch}} on the :latest tag, so every push to main moved it. Since the README only ever showed :latest, that made any merge to main an immediate release to every Docker deployment, with no version bump involved.

PyPI was already version-gated. This makes both channels agree: a v* tag is the single release action, and merging to main is safe.

Also adds a tag-selection table to the README so future deployments aren't steered onto a mutable tag by default.